### PR TITLE
[2465]: Add a change-query test to terminal_test.go

### DIFF
--- a/src/terminal.go
+++ b/src/terminal.go
@@ -1796,7 +1796,7 @@ func (t *Terminal) executeChangeQuery(template string) {
 	newQuery := newQuerySB.String()
 	newQuery = strings.TrimSuffix(newQuery, "\n")
 	newQuery = strings.ReplaceAll(newQuery, "\n", " ")
-	t.input = []rune(newQuerySB.String())
+	t.input = []rune(newQuery)
 	t.cx = len(t.input)
 	t.executing.Set(false)
 	cleanTemporaryFiles()

--- a/src/terminal_test.go
+++ b/src/terminal_test.go
@@ -9,6 +9,30 @@ import (
 	"github.com/junegunn/fzf/src/util"
 )
 
+func TestExecuteChangeQuery(t *testing.T) {
+	if !util.IsWindows() {
+		t.Skip("assumes windows platform")
+	}
+
+	// Use case: change query to the file extension of current item/filename
+	// `fzf --delimiter "\." --bind "ctrl-x:change-query(echo {2})"`
+	template := "echo {2}"
+	delim := "."
+	currentItem := newItem("test.txt")
+	want := `"txt"`
+
+	terminal := NewTerminal(&Options{Delimiter: Delimiter{str: &delim}}, &util.EventBox{})
+	terminal.merger = NewMerger(nil, [][]Result{{Result{item: currentItem}}}, false, false)
+	// assert `terminal.merger.lists[0][0].item` == `terminal.currentItem()`
+
+	terminal.executeChangeQuery(template)
+	result := string(terminal.input)
+
+	if result != want {
+		t.Errorf("expected: %q, actual: %q", want, result)
+	}
+}
+
 func newItem(str string) *Item {
 	bytes := []byte(str)
 	trimmed, _, _ := extractColor(str, nil, nil)


### PR DESCRIPTION
The change-query action is not trimming `\r` on windows before it puts it in the query field.

```
=== RUN   TestExecuteChangeQuery
    terminal_test.go:32: expected: "\"txt\"", actual: "\"txt\"\r"
--- FAIL: TestExecuteChangeQuery (0.01s)
```

From cli: `fzf --delimiter "\." --bind "ctrl-x:change-query(echo {2})"`.
